### PR TITLE
fix: 배포 환경 캐싱 문제 해결

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -62,6 +62,7 @@ export async function createPostAction(formData: FormData) {
 
         // 캐시 무효화 및 리다이렉트
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
         redirect(`/posts/${post.id}`);
     } catch (error) {
         throw error;
@@ -147,6 +148,7 @@ export async function updatePostAction(postId: number, formData: FormData) {
         revalidatePath(`/admin/posts/${postId}/edit`);
         revalidatePath(`/posts/${postId}`);
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         // 수정된 글의 상세 페이지로 리다이렉트
         redirect(`/posts/${postId}`);
@@ -289,6 +291,7 @@ export async function deletePostAction(postId: number) {
 
         // 캐시 무효화
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return { success: true };
     } catch (error) {
@@ -503,6 +506,8 @@ export async function createCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return comment;
     } catch (error) {
@@ -557,6 +562,8 @@ export async function updateCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return comment;
     } catch (error) {
@@ -593,6 +600,8 @@ export async function deleteCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return { success: true };
     } catch (error) {


### PR DESCRIPTION
원인은 mutation 후 홈페이지의 캐시를 무효화 하지 못했던 것

- 모든 Server Actions에 홈페이지 캐시 무효화 추가
- Next.js 설정에 적절한 Cache-Control 헤더 추가
- 개발/배포 모드 간 캐싱 동작 차이 해결

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broaden cache invalidation to include the homepage and posts list after creating, updating, or deleting posts and comments.
> 
> - **Server Actions (`src/lib/actions.ts`)**:
>   - **Posts**: Add `revalidatePath('/')` after `createPostAction`, `updatePostAction`, and `deletePostAction`.
>   - **Comments**: Add `revalidatePath('/posts')` and `revalidatePath('/')` after `createCommentAction`, `updateCommentAction`, and `deleteCommentAction`.
>   - Ensures homepage and posts index are refreshed after mutations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 145f1b89f05489cc30f4e2f3bdb2b3ee79f26cb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->