### PR TITLE
v1.0.2: 데이터 mutation 후 홈 캐시 무효화 적용 

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -62,6 +62,7 @@ export async function createPostAction(formData: FormData) {
 
         // 캐시 무효화 및 리다이렉트
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
         redirect(`/posts/${post.id}`);
     } catch (error) {
         throw error;
@@ -147,6 +148,7 @@ export async function updatePostAction(postId: number, formData: FormData) {
         revalidatePath(`/admin/posts/${postId}/edit`);
         revalidatePath(`/posts/${postId}`);
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         // 수정된 글의 상세 페이지로 리다이렉트
         redirect(`/posts/${postId}`);
@@ -289,6 +291,7 @@ export async function deletePostAction(postId: number) {
 
         // 캐시 무효화
         revalidatePath('/posts');
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return { success: true };
     } catch (error) {
@@ -503,6 +506,8 @@ export async function createCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return comment;
     } catch (error) {
@@ -557,6 +562,8 @@ export async function updateCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return comment;
     } catch (error) {
@@ -593,6 +600,8 @@ export async function deleteCommentAction(formData: FormData) {
 
         // 캐시 무효화
         revalidatePath(`/posts/${rawData.post_id}`);
+        revalidatePath('/posts'); // 글 목록 캐시 무효화
+        revalidatePath('/'); // 홈페이지 캐시 무효화
 
         return { success: true };
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `revalidatePath('/')` (and for comments also `/posts`) across post/comment create/update/delete to keep home and list views fresh.
> 
> - **Cache Invalidation**:
>   - Posts:
>     - `createPostAction`, `updatePostAction`, `deletePostAction`: add `revalidatePath('/')` alongside existing `/posts` invalidations.
>   - Comments:
>     - `createCommentAction`, `updateCommentAction`, `deleteCommentAction`: add `revalidatePath('/posts')` and `revalidatePath('/')` in addition to per-post detail invalidation (`/posts/{id}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92f679e4c2e7382a7f0fd2113d56f5e40b4bdcaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게시물, 댓글, 좋아요 관련 작업 후 사이트 콘텐츠 동기화 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->