### PR TITLE
v1.0.3: 특정 Post에 대해 comments_count와 실제 댓글 수의 동기화가 이루어지지 않아 rpc로 이를 구현

### DIFF
--- a/supabase/migrations/20241226_create_comment_count_functions.sql
+++ b/supabase/migrations/20241226_create_comment_count_functions.sql
@@ -1,0 +1,68 @@
+-- 댓글 수 증가/감소를 위한 RPC 함수들
+
+-- 댓글 생성 시 comments_count 증가
+CREATE OR REPLACE FUNCTION increment_comment_count(post_id_param INTEGER)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    UPDATE posts 
+    SET comments_count = comments_count + 1,
+        updated_at = NOW()
+    WHERE id = post_id_param;
+END;
+$$;
+
+-- 댓글 삭제 시 comments_count 감소
+CREATE OR REPLACE FUNCTION decrement_comment_count(post_id_param INTEGER)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    UPDATE posts 
+    SET comments_count = GREATEST(comments_count - 1, 0),
+        updated_at = NOW()
+    WHERE id = post_id_param;
+END;
+$$;
+
+-- 특정 글의 실제 댓글 수와 comments_count 동기화
+CREATE OR REPLACE FUNCTION sync_comment_count(post_id_param INTEGER)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    actual_count INTEGER;
+BEGIN
+    -- 실제 댓글 수 계산
+    SELECT COUNT(*) INTO actual_count
+    FROM comments
+    WHERE post_id = post_id_param;
+    
+    -- posts 테이블의 comments_count 업데이트
+    UPDATE posts 
+    SET comments_count = actual_count,
+        updated_at = NOW()
+    WHERE id = post_id_param;
+END;
+$$;
+
+-- 모든 글의 댓글 수 동기화 (관리용)
+CREATE OR REPLACE FUNCTION sync_all_comment_counts()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    UPDATE posts 
+    SET comments_count = (
+        SELECT COUNT(*)
+        FROM comments
+        WHERE comments.post_id = posts.id
+    ),
+    updated_at = NOW();
+END;
+$$;


### PR DESCRIPTION
#20 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wire comment create/delete to RPCs that adjust `posts.comments_count`, and add SQL functions to maintain/sync counts.
> 
> - **Comments API (`src/lib/comments.ts`)**
>   - On `createComment`, call `rpc('increment_comment_count', { post_id_param })`; log failures without throwing.
>   - On `deleteComment`, first fetch `post_id` with author check, then call `rpc('decrement_comment_count', { post_id_param })`; log failures without throwing.
> - **Database (Supabase migrations)**
>   - Add RPC functions: `increment_comment_count`, `decrement_comment_count`, `sync_comment_count`, and `sync_all_comment_counts` to maintain and reconcile `posts.comments_count`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f127804725a13cc04d59ef4178dd48446eaa01f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 작성 및 삭제 시 게시물의 댓글 수가 자동으로 업데이트됩니다.
  * 댓글 수 동기화 기능으로 정확한 카운트를 유지합니다.

* **버그 수정**
  * 댓글 삭제 시 사용자 권한 검증이 강화되었습니다.
  * 댓글 수 추적의 안정성과 신뢰성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->