### PR TITLE
refactor: 보안 상 필요한 세션 관리(유저 상태, 전역 세션)를 refetchOnWindowFocus를 true로 처리

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,7 +28,7 @@ export function useAuth() {
         },
         staleTime: 60 * 1000, // 1분 동안 캐시 유지
         gcTime: 10 * 60 * 1000, // 10분
-        refetchOnWindowFocus: false,
+        refetchOnWindowFocus: true, // 보안을 위해 윈도우 포커스 시 세션 상태 확인
         retry: false,
     });
 
@@ -55,6 +55,8 @@ export function useAuth() {
         },
         enabled: !!session?.user?.id, // 세션이 변하면 프로필 조회 실행
         staleTime: 5 * 60 * 1000, // 5분
+        gcTime: 10 * 60 * 1000, // 10분
+        refetchOnWindowFocus: true, // 프로필 변경사항 즉시 반영
         retry: false,
     });
 

--- a/src/lib/query-provider.tsx
+++ b/src/lib/query-provider.tsx
@@ -17,7 +17,7 @@ export default function QueryProvider({
                         staleTime: 60 * 1000, // 1분
                         gcTime: 10 * 60 * 1000, // 10분
                         retry: 1,
-                        refetchOnWindowFocus: false,
+                        refetchOnWindowFocus: true, // 기본적으로 true
                     },
                     mutations: {
                         retry: 1,


### PR DESCRIPTION
#23 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable window-focus refetch for auth session/profile queries and set it as the default in QueryClient; add profile query gcTime.
> 
> - **Auth** (`src/hooks/useAuth.ts`):
>   - Enable `refetchOnWindowFocus: true` for `['auth','session']` and `['auth','profile', id]` queries.
>   - Add `gcTime: 10 * 60 * 1000` to profile query.
> - **Query Client** (`src/lib/query-provider.tsx`):
>   - Set default `queries.refetchOnWindowFocus: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd3b5205569cdbf29aa62ea0ee85398475a43729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->